### PR TITLE
fix/reference-import

### DIFF
--- a/imports/opentofu-aws-ec2-webserver.yml
+++ b/imports/opentofu-aws-ec2-webserver.yml
@@ -3,7 +3,7 @@ repositories:
     - name: showtime
       description: Show off your automations!
       url: https://github.com/torerodev/showtime.git
-      reference: lab/tofu-aws-ec2-webserver
+      reference: main
       tags:
         - demo
         - lab

--- a/imports/opentofu-aws-ec2-webserver.yml
+++ b/imports/opentofu-aws-ec2-webserver.yml
@@ -1,0 +1,39 @@
+---
+repositories:
+    - name: showtime
+      description: Show off your automations!
+      url: https://github.com/torerodev/showtime.git
+      reference: lab/tofu-aws-ec2-webserver
+      tags:
+        - demo
+        - lab
+        - torero
+
+decorators:
+    - name: deco-aws-ec2-webserver
+      schema:
+        $id: root
+        $schema: http://json-schema.org/draft-07/schema#
+        additionalProperties: false
+        properties:
+            aws_access_key:
+                type: string
+            aws_secret_key:
+                type: string
+        required:
+            - aws_access_key
+            - aws_secret_key
+        type: object
+
+services:
+    - name: aws-ec2-webserver
+      type: opentofu-plan
+      description: Host a web server on AWS EC2
+      working-directory: library/opentofu/aws-ec2-webserver
+      repository: showtime
+      decorator: deco-aws-ec2-webserver
+      tags:
+        - aws
+        - opentofu
+        - torero-automation-gateway
+...

--- a/labs/torero-automation-gateway/torero-automation-gateway.clab.yml
+++ b/labs/torero-automation-gateway/torero-automation-gateway.clab.yml
@@ -17,4 +17,6 @@ topology:
         ENABLE_SSH_ADMIN: "true"
       binds:
         - $PWD/data:/home/admin/data
+      exec:
+        - "runuser -u admin -- torero db import --repository https://github.com/torerodev/showtime.git imports/opentofu-aws-ec2-webserver.yml"
 ...

--- a/library/opentofu/aws-ec2-webserver/main.tf
+++ b/library/opentofu/aws-ec2-webserver/main.tf
@@ -1,0 +1,119 @@
+data "aws_availability_zones" "this" {}
+
+data "aws_ami" "this" {
+
+    most_recent = true
+
+    filter {
+        name   = "name"
+        values = ["debian-12-amd64-*"]
+    }
+
+    filter {
+        name = "virtualization-type"
+        values = ["hvm"]
+    }
+
+    owners = ["136693071363"] # official debian images
+}
+
+resource "random_string" "this" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = format("vpc-%s-webserver", random_string.this.result)
+  }
+
+}
+
+resource "aws_subnet" "this" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.subnet_cidr
+  map_public_ip_on_launch = true
+  availability_zone       = data.aws_availability_zones.this.names[0]
+
+  tags = {
+    Name = format("subnet-%s-webserver", random_string.this.result)
+  }
+
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = format("igw-%s-webserver", random_string.this.result)
+  }
+
+}
+
+resource "aws_route_table" "this" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = format("rtb-%s-webserver", random_string.this.result)
+  }
+
+}
+
+resource "aws_route_table_association" "this" {
+  subnet_id      = aws_subnet.this.id
+  route_table_id = aws_route_table.this.id
+}
+
+resource "aws_security_group" "this" {
+  name        = format("%s-webserver-sg", random_string.this.result)
+  description = "Allow Inbound HTTP traffic"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP Inbound"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow ANY Outbound"
+  }
+
+  tags = {
+    Name = format("sg-%s-webserver", random_string.this.result)
+  }
+
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.this.id
+  instance_type          = "t2.micro"
+  subnet_id              = aws_subnet.this.id
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  # dynamically insert html
+  user_data = templatefile("${path.module}/templates/webserver_user_data.sh", {
+    html_content = file("${path.module}/templates/index.html")
+  })
+
+  tags = {
+    Name = format("ec2-%s-webserver", random_string.this.result)
+  }
+
+}

--- a/library/opentofu/aws-ec2-webserver/outputs.tf
+++ b/library/opentofu/aws-ec2-webserver/outputs.tf
@@ -1,0 +1,3 @@
+output "webserver_url" {
+  value = format("http://%s", aws_instance.this.public_ip)
+}

--- a/library/opentofu/aws-ec2-webserver/provider.tf
+++ b/library/opentofu/aws-ec2-webserver/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}

--- a/library/opentofu/aws-ec2-webserver/templates/index.html
+++ b/library/opentofu/aws-ec2-webserver/templates/index.html
@@ -1,0 +1,20 @@
+cat << 'EOF' > templates/index.html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Torero Showcase</title>
+    <style>
+        body { margin: 0; padding: 0; background-color: #000000; }
+        .container { width: 100%; text-align: left; padding-top: 20px; padding-left: 20px; }
+        img { max-width: 100%; height: auto; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <img src="images/showtime.gif" alt="Torero Showcase" loop>
+    </div>
+</body>
+</html>
+EOF

--- a/library/opentofu/aws-ec2-webserver/templates/webserver_user_data.sh
+++ b/library/opentofu/aws-ec2-webserver/templates/webserver_user_data.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# dependencies
+apt-get update -y
+apt-get install -y apache2 curl
+
+# start/enable apache
+systemctl start apache2
+systemctl enable apache2
+
+# create image directory
+mkdir -p /var/www/html/images
+
+# fetch gif
+curl -L --retry 3 --retry-delay 5 \
+  "https://github.com/torerodev/showtime/blob/main/img/showtime.gif?raw=true" \
+  -o "/var/www/html/images/showtime.gif" || {
+    echo "Failed to download GIF"
+    exit 1
+  }
+
+# write html file
+cat > /var/www/html/index.html << 'EOF'
+${html_content}
+EOF
+
+# set permissions
+chmod -R 755 /var/www/html
+
+echo "GIF webserver setup complete."

--- a/library/opentofu/aws-ec2-webserver/variables.tf
+++ b/library/opentofu/aws-ec2-webserver/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_access_key" {
+  description = "AWS Access Key"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR Block"
+  type        = string
+  default     = "10.5.1.0/24"
+}
+
+variable "subnet_cidr" {
+  description = "Subnet CIDR Block"
+  type        = string
+  default     = "10.5.1.0/27"
+}

--- a/library/opentofu/aws-ec2-webserver/versions.tf
+++ b/library/opentofu/aws-ec2-webserver/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}


### PR DESCRIPTION
## Summary
Updated lab references for import file and inject in lab at runtime:

```yml
---
name: torero-automation-gateway

mgmt:
  network: agw-mgmt
  ipv4-subnet: 1.1.1.0/24

topology:
  nodes:
    agw:
      kind: linux
      image: torerodev/torero:latest
      mgmt-ipv4: 1.1.1.5
      env:
        INSTALL_OPENTOFU: "true"
        OPENTOFU_VERSION: "1.9.0"
        ENABLE_SSH_ADMIN: "true"
      binds:
        - $PWD/data:/home/admin/data
      exec:
        - "runuser -u admin -- torero db import --repository https://github.com/torerodev/showtime.git imports/opentofu-aws-ec2-webserver.yml"
...
```