### PR TITLE
fix/container-registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ topology:
     # torero Automation Gateway node we can run our automations from
     agw:
       kind: linux
-      image: torerodev/torero:${TORERO_VERSION:=latest}  # Use ENV variable to pass version else use default
+      image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}  # Use ENV variable to pass version else use default
       mgmt-ipv4: 1.1.1.5
       env:
         ENABLE_SSH_ADMIN: "true"                         # Enable simple ssh login with admin:admin 

--- a/labs/ansible/arista-eos-config-backup/arista-eos-config-backup.clab.yml
+++ b/labs/ansible/arista-eos-config-backup/arista-eos-config-backup.clab.yml
@@ -9,7 +9,7 @@ topology:
   nodes:
     agw:
       kind: linux
-      image: torerodev/torero:${TORERO_VERSION:=latest}
+      image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}
       labels:
         graph-icon: controller
       mgmt-ipv4: 1.1.1.5

--- a/labs/opentofu/aws-ec2-webserver/aws-ec2-webserver.clab.yml
+++ b/labs/opentofu/aws-ec2-webserver/aws-ec2-webserver.clab.yml
@@ -9,7 +9,7 @@ topology:
   nodes:
     agw:
       kind: linux
-      image: torerodev/torero:${TORERO_VERSION:=latest}
+      image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}
       mgmt-ipv4: 1.1.1.5
       labels:
         graph-icon: controller

--- a/labs/python/arista-eos-bgp-basic/arista-eos-bgp-basic.clab.yml
+++ b/labs/python/arista-eos-bgp-basic/arista-eos-bgp-basic.clab.yml
@@ -9,7 +9,7 @@ topology:
   nodes:
     agw:
       kind: linux
-      image: torerodev/torero:${TORERO_VERSION:=latest}
+      image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}
       labels:
         graph-icon: controller
       mgmt-ipv4: 1.1.1.5


### PR DESCRIPTION
## Summary
Container image has moved from dockerhub -> GHCR. This PR updates the links to existing clab files which pull the docker image for torero.

### Old Image Path
torerodev/torero

### New Image Path
ghcr.io/torerodev/torero-container