### PR TITLE
lab/move-to-pyproject

### DIFF
--- a/library/ansible/pyproject.toml
+++ b/library/ansible/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ansible-arista-eos-config-backup"
+version = "0.1.0"
+description = "Ansible project for Arista EOS configuration backup"
+requires-python = ">=3.8"
+dependencies = [
+    "paramiko>=2.11.0",
+    "netmiko>=4.1.0",
+    "requests>=2.28.1",
+    "PyYAML>=6.0",
+    "jinja2>=3.1.2",
+    "ncclient>=0.6.13",
+    "jsonschema>=4.17.3",
+    "pyeapi>=0.8.4",
+]
+
+[tool.setuptools]
+packages = []

--- a/library/ansible/requirements.txt
+++ b/library/ansible/requirements.txt
@@ -1,8 +1,0 @@
-paramiko>=2.11.0
-netmiko>=4.1.0
-requests>=2.28.1
-PyYAML>=6.0
-jinja2>=3.1.2
-ncclient>=0.6.13
-jsonschema>=4.17.3
-pyeapi>=0.8.4

--- a/library/python/arista-eos-bgp-basic/pyproject.toml
+++ b/library/python/arista-eos-bgp-basic/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "arista-eos-bgp-basic"
+version = "0.1.0"
+description = "Python project for basic Arista EOS BGP configuration"
+requires-python = ">=3.8"
+dependencies = [
+    "netmiko>=4.3.0,<5.0.0",
+    "PyYAML>=6.0,<7.0",
+    "python-dateutil>=2.8.2,<3.0.0",
+    "pydantic>=2.0.0,<3.0.0",
+    "colorlog>=6.7.0,<7.0.0",
+    "tenacity>=8.2.3,<9.0.0",
+]
+
+[tool.setuptools]
+packages = []

--- a/library/python/arista-eos-bgp-basic/requirements.txt
+++ b/library/python/arista-eos-bgp-basic/requirements.txt
@@ -1,6 +1,0 @@
-netmiko>=4.3.0,<5.0.0
-PyYAML>=6.0,<7.0
-python-dateutil>=2.8.2,<3.0.0
-pydantic>=2.0.0,<3.0.0
-colorlog>=6.7.0,<7.0.0
-tenacity>=8.2.3,<9.0.0


### PR DESCRIPTION
## Summary
[torero 1.4](https://docs.torero.dev/en/latest/releasenotes/#torero-140) added support for pyproject.toml - this PR transitions labs from requirements.txt to pyproject.toml.

### Example Python Configuration
```bash
[build-system]
requires = ["setuptools>=61.0", "wheel"]
build-backend = "setuptools.build_meta"

[project]
name = "arista-eos-bgp-basic"
version = "0.1.0"
description = "Python project for basic Arista EOS BGP configuration"
requires-python = ">=3.8"
dependencies = [
    "netmiko>=4.3.0,<5.0.0",
    "PyYAML>=6.0,<7.0",
    "python-dateutil>=2.8.2,<3.0.0",
    "pydantic>=2.0.0,<3.0.0",
    "colorlog>=6.7.0,<7.0.0",
    "tenacity>=8.2.3,<9.0.0",
]

[tool.setuptools]
packages = []
```