### PR TITLE
Lab/opentofu runner

### DIFF
--- a/imports/opentofu.yml
+++ b/imports/opentofu.yml
@@ -1,0 +1,22 @@
+---
+repositories:
+    - name: showtime
+      description: Automation Library
+      url: https://github.com/torerodev/showtime.git
+      reference: lab/opentofu-runner
+      tags:
+        - lab
+        - torero
+
+services:
+    - name: aws-state-backend
+      type: opentofu-plan
+      description: AWS state backend
+      working-directory: library/opentofu/aws-state-backend
+      repository: showtime
+      tags:
+        - aws
+        - dynamodb
+        - opentofu
+        - s3
+...

--- a/imports/opentofu.yml
+++ b/imports/opentofu.yml
@@ -3,7 +3,6 @@ repositories:
     - name: showtime
       description: Automation Library
       url: https://github.com/torerodev/showtime.git
-      reference: lab/opentofu-runner
       tags:
         - lab
         - torero
@@ -19,4 +18,5 @@ services:
         - dynamodb
         - opentofu
         - s3
+        - state
 ...

--- a/labs/opentofu/cloud-runner/cloud-runner.clab.yml
+++ b/labs/opentofu/cloud-runner/cloud-runner.clab.yml
@@ -11,13 +11,13 @@ topology:
       kind: linux
       image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}
       mgmt-ipv4: 198.18.1.5
-      ports:
-        - "8000:8000"
-        - "8080:8080"
+      # ports:
+      #   - "8000:8000"
+      #   - "8080:8080"
       env:
         ENABLE_SSH_ADMIN: "true"
-        ENABLE_API: "true"
-        ENABLE_MCP: "true"
+        # ENABLE_API: "true"
+        # ENABLE_MCP: "true"
         INSTALL_OPENTOFU: "true"
         OPENTOFU_VERSION: "1.9.0"
       binds:

--- a/labs/opentofu/cloud-runner/cloud-runner.clab.yml
+++ b/labs/opentofu/cloud-runner/cloud-runner.clab.yml
@@ -1,0 +1,27 @@
+---
+name: cloud-runner
+
+mgmt:
+  network: cloud-runner
+  ipv4-subnet: 198.18.1.0/24
+
+topology:
+  nodes:
+    agw:
+      kind: linux
+      image: ghcr.io/torerodev/torero-container:${TORERO_VERSION:=latest}
+      mgmt-ipv4: 198.18.1.5
+      ports:
+        - "8000:8000"
+        - "8080:8080"
+      env:
+        ENABLE_SSH_ADMIN: "true"
+        ENABLE_API: "true"
+        ENABLE_MCP: "true"
+        INSTALL_OPENTOFU: "true"
+        OPENTOFU_VERSION: "1.9.0"
+      binds:
+        - $PWD/data:/home/admin/data
+      exec:
+        - "runuser -u admin -- torero db import --repository https://github.com/torerodev/showtime.git imports/opentofu.yml"
+...

--- a/library/opentofu/aws-state-backend/main.tf
+++ b/library/opentofu/aws-state-backend/main.tf
@@ -1,0 +1,54 @@
+resource "aws_s3_bucket" "state_bucket" {
+  bucket = var.bucket_name
+
+  tags = {
+    Name    = var.bucket_name
+    Project = var.project_name
+  }
+
+}
+
+resource "aws_s3_bucket_versioning" "state_bucket_versioning" {
+  bucket = aws_s3_bucket.state_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state_bucket_encryption" {
+  bucket = aws_s3_bucket.state_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+
+}
+
+resource "aws_s3_bucket_public_access_block" "state_bucket_public_access" {
+  bucket                  = aws_s3_bucket.state_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "state_lock_table" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name    = var.dynamodb_table_name
+    Project = var.project_name
+  }
+
+}

--- a/library/opentofu/aws-state-backend/outputs.tf
+++ b/library/opentofu/aws-state-backend/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket for OpenTofu state"
+  value       = aws_s3_bucket.state_bucket.bucket
+}
+
+output "s3_bucket_region" {
+  description = "Region of the S3 bucket"
+  value       = aws_s3_bucket.state_bucket.region
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for state locking"
+  value       = aws_dynamodb_table.state_lock_table.name
+}

--- a/library/opentofu/aws-state-backend/provider.tf
+++ b/library/opentofu/aws-state-backend/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}

--- a/library/opentofu/aws-state-backend/variables.tf
+++ b/library/opentofu/aws-state-backend/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_access_key" {
+  description = "AWS access key"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key"
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_region" {
+  description = "AWS region to create resources in"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "torero-showtime-backend"
+}
+
+variable "bucket_name" {
+  description = "Unique name for the S3 bucket"
+  type        = string
+  default     = "torero-showtime-backend"
+}
+
+variable "dynamodb_table_name" {
+  description = "Name for the DynamoDB lock table"
+  type        = string
+  default     = "torero-showtime-state-lock"
+}

--- a/library/opentofu/aws-state-backend/versions.tf
+++ b/library/opentofu/aws-state-backend/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
# ✨ Lab: OpenTofu Cloud Runner

## 📒 Summary
Sets up an OpenTofu cloud runner environment with AWS state backend infrastructure for managing remote state storage and locking. This can be referenced in subsequent service executions for handling _OpenTofu state_.

## 🔧 Changes
- Added containerlab topology for cloud-runner with torero container configured for OpenTofu
- Created AWS state backend with S3 bucket for state storage and DynamoDB table for state locking
- Configured S3 bucket with versioning, encryption, and public access restrictions
- Added OpenTofu import file for registering aws-state-backend service in torero
- Included provider configuration and variable definitions for AWS resources